### PR TITLE
BuildSystem: clean target and minor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
 all:
-	@echo "Building posix utilities..."
+	@echo "=== POSIX UTILITIES ==="
 	@${MAKE} --no-print-directory -C posix/ -f Makefile
+
+clean:
+	@echo "Cleaning posix utilities..."
+	cd posix/; ${MAKE} --no-print-directory -f Makefile clean
+

--- a/posix/Makefile
+++ b/posix/Makefile
@@ -5,7 +5,7 @@ UTILITIES=bin/basename bin/cat bin/false  bin/nohup bin/pwd bin/sleep bin/true
 
 all: $(UTILITIES)
 
-bin/%: %.cc $(DEPS)
+bin/%: %.cc 
 	@echo "Building $(notdir $<)"
 	@ mkdir -p bin
 	@ $(CC) -o $@ $< $(CFLAGS)


### PR DESCRIPTION
The clean target has been added to the main makefile (that calls the make target of the subprojects). Also, posix makefile has been cleaned up (removed unnecessary dependencies on building).