### PR TITLE
Poxixutils: basename without any directory bugfix

### DIFF
--- a/posix/basename.cc
+++ b/posix/basename.cc
@@ -24,7 +24,7 @@ static std::string calculate_basename(const std::string& string) {
         }
     }
 
-    return std::string{};
+    return string;
 }
 
 static std::string remove_suffix(const std::string& string, const std::string& suffix) {


### PR DESCRIPTION
Referring to bug #32.

The issue was that the function `calculate_basename` was returning nothing when the character `/` was not found on the string. That's fixed by returning the string itself when the character `/` was not found.